### PR TITLE
Addresses memory usage in predict_conf_int

### DIFF
--- a/pyrsm/logit.py
+++ b/pyrsm/logit.py
@@ -149,7 +149,7 @@ def predict_conf_int(fitted, df, alpha=0.05):
 
     low, high = [alpha / 2, 1 - (alpha / 2)]
     Xb = np.dot(df, fitted.params)
-    se = np.sqrt(np.diag(df.dot(fitted.cov_params()).dot(np.transpose(df))))
+    se = np.sqrt((df.dot(fitted.cov_params()) * df).sum(-1))
     me = norm.ppf(high) * se
     lb = np.exp(Xb - me)
     ub = np.exp(Xb + me)


### PR DESCRIPTION
Only needed to extract diagonal elements of the matrix, which can be done by just taking the sum over the scalar product. See ["Stackoverflow: Is there a numpy/scipy dot product, calculating only the diagonal entries of the result?"](https://stackoverflow.com/questions/14758283/is-there-a-numpy-scipy-dot-product-calculating-only-the-diagonal-entries-of-the/14759341).

```{python}
import numpy as np
import statsmodels.formula.api as smf
import pandas as pd
import matplotlib.pyplot as plt


def setup(n):
    # Simulate data
    np.random.seed(1)
    x1 = np.arange(n)
    x2 = pd.Series(["a", "b", "c", "a"], dtype="category").sample(n, replace=True)
    y = (x1 * 0.5 + np.random.normal(size=n, scale=10) > 30).astype(int)
    df = pd.DataFrame({"y": y, "x1": x1, "x2": x2})

    # Estimate the model
    model = smf.logit(formula="y ~ x1 + x2", data=df).fit(disp=0)
    model.summary()

    # Replicate parts of predict_conf_int
    fitted = model
    prediction = fitted.predict(df)

    # adding a fake endogenous variable
    df = df.copy()  # making a full copy
    df["__endog__"] = 1
    form = "__endog__ ~ " + fitted.model.formula.split("~", 1)[1]
    df = smf.logit(formula=form, data=df).exog
    return df, fitted


df, fitted = setup(10_000)

se_old = np.sqrt(np.diag(df.dot(fitted.cov_params()).dot(np.transpose(df))))
se_new = np.sqrt((df.dot(fitted.cov_params()) * df).sum(-1))

print(
    f"Testing whether previous method results in same std errors: {np.allclose(se_old, se_new)}"
)
```